### PR TITLE
Add support for alternative gdbus monitor on Linux.

### DIFF
--- a/lib/desktop_screenstate.dart
+++ b/lib/desktop_screenstate.dart
@@ -16,9 +16,13 @@ class DesktopScreenState {
   /// Set the screen state monitor to use on Linux
   static var linuxMonitor = ScreenStateMonitor.dbus;
 
+  static bool _disposing = false;
+  static int _dbusPid = 0;
+  static int _gdbusPid = 0;
+
   /// Singleton instance of DesktopScreenState
   static DesktopScreenState? _instance;
-  static DesktopScreenState get instance => _instance ?? _createInstance();
+  static DesktopScreenState get instance => _instance ??= _createInstance();
 
   static DesktopScreenState _createInstance() {
     final instance = DesktopScreenState._();
@@ -28,10 +32,10 @@ class DesktopScreenState {
     } else if (Platform.isLinux) {
       switch (linuxMonitor) {
         case ScreenStateMonitor.gdbus:
-          runGdbusLinuxMonitor();
+          _runGdbusLinuxMonitor();
           break;
         case ScreenStateMonitor.dbus:
-          runDbusLinuxMonitor();
+          _runDbusLinuxMonitor();
           break;
       }
     }
@@ -39,11 +43,23 @@ class DesktopScreenState {
     return instance;
   }
 
-  static void runDbusLinuxMonitor() {
+  static void dispose() {
+    _disposing = true;
+    _stopDbusLinuxMonitor();
+    _stopGdbusLinuxMonitor();
+  }
+
+  static void _runDbusLinuxMonitor() async {
+    if (_disposing) {
+      return;
+    }
+
+    _stopDbusLinuxMonitor();
     Process.start('dbus-monitor', [
       '--session',
       "type='signal',interface='org.gnome.ScreenSaver'"
     ]).then((Process process) {
+      _dbusPid = process.pid;
       // Capture stdout and stderr streams
       process.stdout
           .transform(utf8.decoder)
@@ -62,23 +78,35 @@ class DesktopScreenState {
 
       // Listen for process exit
       process.exitCode.then((int code) {
-        debugPrint('Process exited with code $code');
+        debugPrint('dbus-monitor exited with code $code');
+        _dbusPid = 0;
         // Handle process exit, if needed
       });
     }).catchError((error) {
-      debugPrint('Error starting process: $error');
+      debugPrint('Error starting dbus-monitor: $error');
       // Handle any errors that occur during process startup
     });
+  }
+
+  static void _stopDbusLinuxMonitor() {
+    _killPid(_dbusPid);
+    _dbusPid = 0;
   }
 
   // Regex to find the Session IdleHint property and capture its boolean value
   static final _idleHintRegex =
       RegExp(r"Session.*'IdleHint'\s*:\s*<(?<value>true|false)>");
 
-  static void runGdbusLinuxMonitor() {
+  static void _runGdbusLinuxMonitor() async {
+    if (_disposing) {
+      return;
+    }
+
+    _stopGdbusLinuxMonitor();
     Process.start(
             'gdbus', ['monitor', '--system', '--dest=org.freedesktop.login1'])
         .then((Process process) {
+      _gdbusPid = process.pid;
       // Capture stdout and stderr streams
       process.stdout
           .transform(utf8.decoder)
@@ -100,13 +128,20 @@ class DesktopScreenState {
 
       // Listen for process exit
       process.exitCode.then((int code) {
-        debugPrint('Process exited with code $code');
-        // Handle process exit, if needed
+        debugPrint('gdbus exited with code $code');
+        _gdbusPid = 0;
+        // Restart the monitor
+        _runGdbusLinuxMonitor();
       });
     }).catchError((error) {
-      debugPrint('Error starting process: $error');
+      debugPrint('Error starting gdbus: $error');
       // Handle any errors that occur during process startup
     });
+  }
+
+  static void _stopGdbusLinuxMonitor() {
+    _killPid(_gdbusPid);
+    _gdbusPid = 0;
   }
 
   DesktopScreenState._();
@@ -130,5 +165,19 @@ class DesktopScreenState {
       (e) => e.toString().split('.').last == active,
       orElse: () => ScreenState.awaked,
     );
+  }
+}
+
+void _killPid(int pid) {
+  if (pid <= 0) {
+    return;
+  }
+
+  try {
+    Process.killPid(pid, ProcessSignal.sigint);
+    Process.killPid(pid, ProcessSignal.sigterm);
+    Process.killPid(pid, ProcessSignal.sigkill);
+  } catch (e) {
+    debugPrint('Error killing process $pid: $e');
   }
 }

--- a/lib/desktop_screenstate.dart
+++ b/lib/desktop_screenstate.dart
@@ -84,7 +84,6 @@ class DesktopScreenState {
           .transform(utf8.decoder)
           .transform(const LineSplitter())
           .listen((String line) {
-        debugPrint(line);
         // Check if the line contains the IdleHint property change
         final match = _idleHintRegex.firstMatch(line);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_screenstate
 description: Flutter package to detect desktop screen is on or off.
-version: 0.0.5
+version: 0.0.5+1
 homepage: https://github.com/alihassan143/Screenstate
 
 environment:


### PR DESCRIPTION
The dbus_monitor does not work reliably on all systems. This change adds support for gdbus as an alternative monitor.
This also adds support for gracefully shutting down the external process instead of leaving it running. Eventually, all system resources would be consumed if the application is restarted multiple times.